### PR TITLE
CuArray/CPU Array rrules

### DIFF
--- a/src/CUDArules.jl
+++ b/src/CUDArules.jl
@@ -2,5 +2,20 @@ module CUDArules
     using CUDA
     using ChainRulesCore
 
-    f() = println("Hello, world!")
+    to_gpu(a::AbstractArray) = CuArray(a)
+    function rrule(::typeof(to_gpu), a::AbstractArray)
+        project_a = ProjectTo(a)
+        Ω = to_gpu(a)
+        pb(Δ) = (NoTangent(), project_a(collect(Δ)))
+        return Ω, pb
+    end
+
+    to_cpu(a::AbstractArray) = a
+    to_cpu(a::CuArray) = Array(a)
+    function rrule(::typeof(to_cpu), a::CuArray)
+        Ω = to_cpu(a)
+        pb(Δ) = (NoTangent(), CuArray(Δ))
+        return Ω, pb
+    end
+
 end


### PR DESCRIPTION
Implements `to_gpu` and `to_cpu` for moving an `AbstractArray` to a `CuArray` and a `CuArray` to generic `Array`, respectively. Accompanying `rrule`s are included.

High level thoughts: `to_gpu` can probably be salvaged for a more general `CUDA.cu` `rrule`, since we basically just need to transfer the `CuArray` back to the proper CPU array type. Might be appropriate to `@thunk` it? 

`to_cpu` seems more difficult, in part because I'm not sure what the proper method(s) are that need rules for materializing the GPU array back in main memory instead of `to_cpu`. My instinct is that it seems like it's better suited to a `ProjectTo` method for various `GPUArray` types, but I haven't spent much time looking at how these projections work for more exotic arrays